### PR TITLE
Add `[Exposed=Window]` to (partial) interfaces

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -151,6 +151,7 @@ Event Timing involves the following new interfaces:
 ------------------------------------------------------------------------
 
 <pre class="idl">
+[Exposed=Window]
 interface PerformanceEventTiming : PerformanceEntry {
     readonly attribute DOMHighResTimeStamp processingStart;
     readonly attribute DOMHighResTimeStamp processingEnd;
@@ -208,6 +209,7 @@ Each {{PerformanceEventTiming}} object reports timing information about an <dfn 
 ------------------------
 
 <pre class="idl">
+[Exposed=Window]
 interface EventCounts {
     readonly maplike&lt;DOMString, unsigned long&gt;;
 };
@@ -220,6 +222,7 @@ Extensions to the {{Performance}} interface {#sec-extensions}
 ------------------------
 
 <pre class="idl">
+[Exposed=Window]
 partial interface Performance {
     readonly attribute EventCounts eventCounts;
 };


### PR DESCRIPTION
This is required by https://heycam.github.io/webidl/#idl-interfaces

For `partial interface Performance` this matters because
`performance.eventCounts` would otherwise also be exposed to workers.