### PR TITLE
Fixes in algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -283,8 +283,8 @@ partial interface Performance {
 };
 </pre>
 
-The {{Performance/eventCounts}} attribute's getter returns a map with entries of the form <var>type</var> → <var>num-events</var>.
-This means that there have been <var>num-events</var> dispatched such that their {{Event/type}} attribute value is equal to <var>type</var>.
+The {{Performance/eventCounts}} attribute's getter returns a map with entries of the form <var>type</var> → <var>numEvents</var>.
+This means that there have been <var>numEvents</var> dispatched such that their {{Event/type}} attribute value is equal to <var>type</var>.
 
 Processing model {#sec-processing-model}
 ========================================
@@ -325,16 +325,16 @@ Initialize event timing {#sec-init-event-timing}
 --------------------------------------------------------
 
 <div algorithm="initialize event timing">
-    When asked to <dfn export>initialize event timing</dfn>, with <var>event</var> and <var>processing start</var> as inputs, run the following steps:
+    When asked to <dfn export>initialize event timing</dfn>, with <var>event</var> and <var>processingStart</var> as inputs, run the following steps:
 
     1. If the algorithm to determine if <var>event</var> should be <a>considered for Event Timing</a> returns false, then return null.
     1. Let <var>timingEntry</var> be a new {{PerformanceEventTiming}} object.
     1. Set <var>timingEntry</var>'s {{PerformanceEntry/name}} to <var>event</var>'s {{Event/type}} attribute value.
     1. Set <var>timingEntry</var>'s {{PerformanceEntry/entryType}} to "<code>event</code>".
     1. Set <var>timingEntry</var>'s {{PerformanceEntry/startTime}} as follows:
-        1. If <var>event</var>'s {{Event/type}} attribute value is equal to "<code>pointermove</code>", set <var>timingEntry</var>'s {{PerformanceEntry/startTime}} to <code><var>event</var>.<a>getCoalescedEvents()</a>[0].{{PerformanceEntry/startTime}}</code>.
-        1. Otherwise, set <var>timingEntry</var>'s {{PerformanceEntry/startTime}} to <code><var>event</var>.{{Event/timeStamp}}</code>.
-    1. Set <var>timingEntry</var>'s {{processingStart}} to <var>processing start</var>.
+        1. If <var>event</var>'s {{Event/type}} attribute value is equal to "<code>pointermove</code>", set <var>timingEntry</var>'s {{PerformanceEntry/startTime}} to the {{Event/timeStamp}} attribute value of the first entry of the list returned by the <a>getCoalescedEvents()</a> algorithm applied to <var>event</var>.
+        1. Otherwise, set <var>timingEntry</var>'s {{PerformanceEntry/startTime}} to <var>event</var>'s {{Event/timeStamp}} attribute value.
+    1. Set <var>timingEntry</var>'s {{processingStart}} to <var>processingStart</var>.
     1. Set <var>timingEntry</var>'s {{cancelable}} to <var>event</var>'s {{Event/cancelable}} attribute value.
     1. Return <var>timingEntry</var>.
 </div>
@@ -343,13 +343,13 @@ Finalize event timing {#sec-fin-event-timing}
 --------------------------------------------------------
 
 <div algorithm="finalize event timing">
-    When asked to to <dfn export>finalize event timing</dfn>, with <var>timingEntry</var>, <var>target</var>, and <var>processing end</var> as inputs, run the following steps:
+    When asked to to <dfn export>finalize event timing</dfn>, with <var>timingEntry</var>, <var>target</var>, and <var>processingEnd</var> as inputs, run the following steps:
 
     1. If <var>timingEntry</var> is null, return.
-    1. Let <var>relevant global</var> be <var>target</var>'s <a>relevant global object</a>.
-    1. If <var>relevant global</var> does not <a>implement</a> {{Window}}, return.
-    1. Set <var>timingEntry</var>'s {{processingEnd}} to <var>processing end</var>.
-    1. Append <var>timingEntry</var> to <var>relevant global</var>’s <a>pending event entries</a>.
+    1. Let <var>relevantGlobal</var> be <var>target</var>'s <a>relevant global object</a>.
+    1. If <var>relevantGlobal</var> does not <a>implement</a> {{Window}}, return.
+    1. Set <var>timingEntry</var>'s {{processingEnd}} to <var>processingEnd</var>.
+    1. Append <var>timingEntry</var> to <var>relevantGlobal</var>’s <a>pending event entries</a>.
 </div>
 
 Dispatch pending Event Timing entries {#sec-dispatch-pending}
@@ -359,24 +359,29 @@ Dispatch pending Event Timing entries {#sec-dispatch-pending}
     When asked to <dfn export>dispatch pending Event Timing entries</dfn> for a {{Document}} <var>doc</var>, run the following steps:
 
     1. Let <var>window</var> be <var>doc</var>'s <a>relevant global object</a>.
-    1. Let <var>rendering-timestamp</var> be the <a>current high resolution time</a>.
+    1. Let <var>renderingTimestamp</var> be the <a>current high resolution time</a>.
     1. For each <var>timingEntry</var> in <var>window</var>'s <a>pending event entries</a>:
+        1. Let <var>start</var> be <var>timingEntry</var>'s {{PerformanceEntry/startTime}} attribute value.
         1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} by running the following steps:
-            1. Let <var>difference</var> be <code><var>rendering-timestamp</var> - <var>timingEntry</var>.{{PerformanceEntry/startTime}}</code>.
-            1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} to <code><a>Math.round</a>(<var>difference</var>/8)*8</code>.
+            1. Let <var>difference</var> be <code><var>renderingTimestamp</var> - <var>start</var></code>.
+            1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} to the result of rounding <var>difference</var> to the nearest multiple of 8.
+        1. Let <var>name</var> be <var>timingEntry</var>'s {{PerformanceEntry/name}} attribute value.
         1. Perform the following steps to update the event counts:
-            1. If <code><var>window</var>.{{WindowOrWorkerGlobalScope/performance}}.{{Performance/eventCounts}}</code> does not contain a key <code><var>timingEntry</var>.{{PerformanceEntry/name}}</code>, then set <code><var>window</var>.{{WindowOrWorkerGlobalScope/performance}}.{{Performance/eventCounts}}[<var>timingEntry</var>.{{PerformanceEntry/name}}]</code> to 1.
-            1. Otherwise, increase <code><var>window</var>.{{WindowOrWorkerGlobalScope/performance}}.{{Performance/eventCounts}}[<var>timingEntry</var>.{{PerformanceEntry/name}}]</code> by 1.
+            1. Let <var>performance</var> be <var>window</var>'s {{WindowOrWorkerGlobalScope/performance}} attribute value.
+            1. If <var>performance</var>'s {{Performance/eventCounts}} attribute value does not contain a <a>map entry</a> whose key is <var>name</var>, then:
+                1. Let <var>mapEntry</var> be a new <a>map entry</a> with key equal to <var>name</var> and value equal to 1.
+                1. Add <var>mapEntry</var> to <var>performance</var>'s {{Performance/eventCounts}} attribute value.
+            1. Otherwise, increase the <a>map entry</a>'s value by 1.
         1. If <var>timingEntry</var>'s {{PerformanceEntry/duration}} attribute value is greater than or equal to 104, then <a lt='queue the entry'>queue</a> <var>timingEntry</var>.
         1. If <var>window</var>'s <a>has dispatched event</a> is false, run the following steps:
-            1. If <var>timingEntry</var>'s {{PerformanceEntry/name}} attribute value is "<code>pointerdown</code>", run the following steps:
+            1. If <var>name</var> is "<code>pointerdown</code>", run the following steps:
                 1. Set <var>window</var>'s <a>pending pointer down</a> to a copy of <var>timingEntry</var>.
                 1. Set the {{PerformanceEntry/entryType}} of <var>window</var>'s <a>pending pointer down</a> to "<code>firstInput</code>".
             1. Otherwise, run the following steps:
-                1. If <var>timingEntry</var>'s {{PerformanceEntry/name}} attribute value is "<code>pointerup</code>" AND if <var>window</var>'s <a>pending pointer down</a> is not null, then:
+                1. If <var>name</var> is "<code>pointerup</code>" AND if <var>window</var>'s <a>pending pointer down</a> is not null, then:
                     1. Set <var>window</var>'s <a>has dispatched event</a> to true.
                     1. <a lt='queue the entry'>Queue</a> <var>window</var>'s <a>pending pointer down</a>.
-                1. Otherwise, if <var>timingEntry</var>'s {{PerformanceEntry/name}} attribute value is one of "<code>click</code>", "<code>keydown</code>" or "<code>mousedown</code>", then:
+                1. Otherwise, if <var>name</var> is one of "<code>click</code>", "<code>keydown</code>" or "<code>mousedown</code>", then:
                     1. Set <var>window</var>'s <a>has dispatched event</a> to true.
                     1. Let <var>newFirstInputDelayEntry</var> be a copy of <var>timingEntry</var>.
                     1. Set <var>newFirstInputDelayEntry</var>'s {{PerformanceEntry/entryType}} to "<code>firstInput</code>".


### PR DESCRIPTION
Fixes https://github.com/WICG/event-timing/issues/31
Fixes https://github.com/WICG/event-timing/issues/33
This PR does the following changes:
* Use camelCase consistently for `<var>`s.
* Remove JavaScript-like text in algorithms.
* Describe the maplike changes in prose.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/pull/46.html" title="Last updated on May 15, 2019, 9:05 PM UTC (7e8d865)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/46/557c00b...7e8d865.html" title="Last updated on May 15, 2019, 9:05 PM UTC (7e8d865)">Diff</a>