### PR TITLE
Fix description of processingStart/End in spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -170,11 +170,9 @@ Usage example {#sec-example}
 <pre class="example highlight">
     const observer = new PerformanceObserver(function(list) {
         const perfEntries = list.getEntries().forEach(entry => {
-            if (entry.processingStart !== 0) {
-                const inputDelay = entry.processingStart - entry.startTime;
-                // Report the input delay when the processing start was provided.
-            }
-            // Report full input duration via entry.duration.
+            const inputDelay = entry.processingStart - entry.startTime;
+            // Report the input delay when the processing start was provided.
+            // Also report the full input duration via entry.duration.
         });
     });
     // Register observer for event.
@@ -246,13 +244,11 @@ Each {{PerformanceEventTiming}} object reports timing information about an <dfn 
 <dl dfn-type=attribute dfn-for=PerformanceEventTiming link-for=PerformanceEventTiming>
     <dt>{{processingStart}}</dt>
     <dd>
-        The <dfn export>processingStart</dfn> attribute's getter returns the time when event handlers start to execute, or
-        0 if the event dispatching logic is skipped (this can happen when there are no event handlers).
+        The <dfn export>processingStart</dfn> attribute's getter returns the time when event handlers start to execute.
     </dd>
     <dt>{{processingEnd}}</dt>
     <dd>
-        The <dfn export>processingEnd</dfn> attribute's getter returns the time when event handlers have finished executing, or
-        0 if the event dispatching logic is skipped (this can happen when there are no event handlers).
+        The <dfn export>processingEnd</dfn> attribute's getter returns the time when event handlers have finished executing. It could be equal to {{processingStart}} when there are no such event handlers.
     </dd>
     <dt>{{cancelable}}</dt>
     <dd>
@@ -308,7 +304,7 @@ Modifications to the DOM specification {#sec-modifications-DOM}
     * <a>Finalize event timing</a> passing <var>timingEntry</var>, <em>target</em>, and the <a>current high resolution time</a> as inputs.
 </div>
 
-Note: If the user agent skips the <a>event dispatch algorithm</a>, it can still choose to include an entry for that {{Event}}.
+Note: If a user agent skips the <a>event dispatch algorithm</a>, it can still choose to include an entry for that {{Event}}.
 In this case, it will estimate the value of {{PerformanceEventTiming/processingStart}} and set the {{PerformanceEventTiming/processingEnd}} to the same value.
 
 Modifications to the HTML specification {#sec-modifications-HTML}

--- a/index.bs
+++ b/index.bs
@@ -244,11 +244,11 @@ Each {{PerformanceEventTiming}} object reports timing information about an <dfn 
 <dl dfn-type=attribute dfn-for=PerformanceEventTiming link-for=PerformanceEventTiming>
     <dt>{{processingStart}}</dt>
     <dd>
-        The <dfn export>processingStart</dfn> attribute's getter returns the time when event handlers start to execute.
+        The <dfn export>processingStart</dfn> attribute's getter returns a timestamp captured at the beginning of the <a link-for=''>event dispatch algorithm</a>. This is when event handlers are about to be executed.
     </dd>
     <dt>{{processingEnd}}</dt>
     <dd>
-        The <dfn export>processingEnd</dfn> attribute's getter returns the time when event handlers have finished executing. It could be equal to {{processingStart}} when there are no such event handlers.
+        The <dfn export>processingEnd</dfn> attribute's getter returns a timestamp captured at the end of the <a link-for=''>event dispatch algorithm</a>. This is when event handlers have finished executing. It's equal to {{processingStart}} when there are no such event handlers.
     </dd>
     <dt>{{cancelable}}</dt>
     <dd>


### PR DESCRIPTION
The non-normative section describing the processingStart and processingEnd attributes allows them to be set to 0, but we've decided to not allow this for now. Thus, we remove this from the description. The non-normative note describing how they are set when the event dispatching logic is skipped (by 'estimating' them) is not removed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/pull/59.html" title="Last updated on Sep 20, 2019, 5:20 AM UTC (2785995)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/59/a3bf3f1...2785995.html" title="Last updated on Sep 20, 2019, 5:20 AM UTC (2785995)">Diff</a>