### PR TITLE
Specify the units when rounding

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -385,7 +385,7 @@ Dispatch pending Event Timing entries {#sec-dispatch-pending}
         1. Let <var>start</var> be <var>timingEntry</var>'s {{PerformanceEntry/startTime}} attribute value.
         1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} by running the following steps:
             1. Let <var>difference</var> be <code><var>renderingTimestamp</var> - <var>start</var></code>.
-            1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} to the [=DOMHighResTimeStamp=] resulting from rounding <var>difference</var> to the nearest multiple of 8ms.
+            1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} to the {{DOMHighResTimeStamp}} resulting from rounding <var>difference</var> to the nearest multiple of 8ms.
         1. Let <var>name</var> be <var>timingEntry</var>'s {{PerformanceEntry/name}} attribute value.
         1. Perform the following steps to update the event counts:
             1. Let <var>performance</var> be <var>window</var>'s {{WindowOrWorkerGlobalScope/performance}} attribute value.

--- a/index.bs
+++ b/index.bs
@@ -385,7 +385,7 @@ Dispatch pending Event Timing entries {#sec-dispatch-pending}
         1. Let <var>start</var> be <var>timingEntry</var>'s {{PerformanceEntry/startTime}} attribute value.
         1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} by running the following steps:
             1. Let <var>difference</var> be <code><var>renderingTimestamp</var> - <var>start</var></code>.
-            1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} to the result of rounding <var>difference</var> to the nearest multiple of 8.
+            1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} to the [=DOMHighResTimeStamp=] resulting from rounding <var>difference</var> to the nearest multiple of 8ms.
         1. Let <var>name</var> be <var>timingEntry</var>'s {{PerformanceEntry/name}} attribute value.
         1. Perform the following steps to update the event counts:
             1. Let <var>performance</var> be <var>window</var>'s {{WindowOrWorkerGlobalScope/performance}} attribute value.


### PR DESCRIPTION
For https://github.com/WICG/event-timing/issues/68


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/pull/70.html" title="Last updated on Mar 25, 2020, 10:54 PM UTC (b24b3a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/70/ab8f967...b24b3a7.html" title="Last updated on Mar 25, 2020, 10:54 PM UTC (b24b3a7)">Diff</a>