### PR TITLE
Add flexibility on duration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -383,9 +383,7 @@ Dispatch pending Event Timing entries {#sec-dispatch-pending}
     1. Let <var>renderingTimestamp</var> be the <a>current high resolution time</a>.
     1. For each <var>timingEntry</var> in <var>window</var>'s <a>pending event entries</a>:
         1. Let <var>start</var> be <var>timingEntry</var>'s {{PerformanceEntry/startTime}} attribute value.
-        1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} by running the following steps:
-            1. Let <var>difference</var> be <code><var>renderingTimestamp</var> - <var>start</var></code>.
-            1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} to the {{DOMHighResTimeStamp}} resulting from rounding <var>difference</var> to the nearest multiple of 8ms.
+        1. Set <var>timingEntry</var>'s {{PerformanceEntry/duration}} to a {{DOMHighResTimeStamp}} resulting from <code><var>renderingTimestamp</var> - <var>start</var></code>, with granularity of 8ms or less.
         1. Let <var>name</var> be <var>timingEntry</var>'s {{PerformanceEntry/name}} attribute value.
         1. Perform the following steps to update the event counts:
             1. Let <var>performance</var> be <var>window</var>'s {{WindowOrWorkerGlobalScope/performance}} attribute value.


### PR DESCRIPTION
Fixes https://github.com/WICG/event-timing/issues/68
@rniwa


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 27, 2020, 5:36 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Fevent-timing%2F1be4107e594ff89b7e024962d128f832d7ef1ade%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Bikeshed has updated to Python 3, but you are trying to run it with
Python 2.7.9. For instructions on upgrading, please check:
https://tabatkins.github.io/bikeshed/#installing
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/event-timing%2373.)._
</details>
