### PR TITLE
Add support for Target in spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -238,7 +238,9 @@ interface PerformanceEventTiming : PerformanceEntry {
 };
 </pre>
 
-Each {{PerformanceEventTiming}} object has an associated <dfn for=PerformanceEventTiming>target</dfn>, which is initially set to null.
+Each {{PerformanceEventTiming}} object has an associated <dfn for=PerformanceEventTiming>eventTarget</dfn>, which is initially set to null.
+
+The <dfn export>target</dfn> attribute's getter returns the result of the <a link-for=''>get an element</a> algorithm, passing the <a link-for=''>context object</a>'s <a>eventTarget</a> and null as inputs.
 
 Note: A user agent implementing the Event Timing API would need to include "<code>first-input</code>" and "<code>event</code>" in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
 This allows developers to detect support for event timing.
@@ -285,7 +287,7 @@ Each {{PerformanceEventTiming}} object reports timing information about an <dfn 
     </dd>
     <dt>{{target}}</dt>
     <dd>
-        The <dfn export>target</dfn> attribute's getter returns the result of the <a link-for=''>get an element</a> algorithm, passing the <a link-for=''>context object</a>'s <a>target</a> and null as inputs.
+        The {{target}} attribute's getter returns the <a>associated event</a>'s last {{Event/target}} when such {{/Node}} is not disconnected nor in the shadow DOM.
     </dd>
 </dl>
 
@@ -385,9 +387,9 @@ Finalize event timing {#sec-fin-event-timing}
 
     Note: this assertion holds due to the types of events supported by the Event Timing API.
 
-    1. Set <var>timingEntry</var>'s <a for=PerformanceEventTiming>target</a> to the result of calling the <a>get an element</a> algorithm with <var>target</var> and <var>relevantGlobal</var>'s <a>associated document</a> as inputs.
+    1. Set <var>timingEntry</var>'s <a for=PerformanceEventTiming>eventTarget</a> to the result of calling the <a>get an element</a> algorithm with <var>target</var> and <var>relevantGlobal</var>'s <a>associated document</a> as inputs.
 
-    Note: This will set <a for=PerformanceEventTiming>target</a> to the last event target. So if <a>retargeting</a> occurs, the last target, closest to the <a for=tree>root</a>, will be used.
+    Note: This will set <a for=PerformanceEventTiming>eventTarget</a> to the last event target. So if <a>retargeting</a> occurs, the last target, closest to the <a for=tree>root</a>, will be used.
 
     Issue: Change the linking of the "get an element" algorithm once it is moved to the DOM spec.
 

--- a/index.bs
+++ b/index.bs
@@ -90,6 +90,8 @@ urlPrefix: https://html.spec.whatwg.org/multipage/; spec: HTML;
     type: event; url: #event-dnd-dragover; text: dragover;
     type: event; url: #event-dnd-drop; text: drop;
     type: event; url: #event-dnd-dragend; text: dragend;
+urlPrefix: https://wicg.github.io/element-timing/; spec: ELEMENT-TIMING;
+    type: dfn; url: #get-an-element; text: get an element;
 </pre>
 
 Introduction {#sec-intro}
@@ -199,6 +201,8 @@ Usage example {#sec-example}
         // Measure the duration of processing the first input event.
         // Only use when the important event handling work is done synchronously in the handlers.
         const firstInputDuration = firstInput.duration;
+        // Obtain some information about the target of this event, such as the id.
+        const targetId = firstInput.target ? firstInput.target.id : 'unknown-target';
         // Process the first input delay and perhaps its duration...
 
         // Disconnect this observer since callback is only triggered once.
@@ -229,9 +233,12 @@ interface PerformanceEventTiming : PerformanceEntry {
     readonly attribute DOMHighResTimeStamp processingStart;
     readonly attribute DOMHighResTimeStamp processingEnd;
     readonly attribute boolean cancelable;
+    readonly attribute Node? target;
     [Default] object toJSON();
 };
 </pre>
+
+Each {{PerformanceEventTiming}} object has an associated <dfn for=PerformanceEventTiming>target</dfn>, which is initially set to null.
 
 Note: A user agent implementing the Event Timing API would need to include "<code>first-input</code>" and "<code>event</code>" in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
 This allows developers to detect support for event timing.
@@ -275,6 +282,10 @@ Each {{PerformanceEventTiming}} object reports timing information about an <dfn 
     <dt>{{cancelable}}</dt>
     <dd>
         The <dfn export>cancelable</dfn> attribute's getter returns the <a>associated event</a>'s {{Event/cancelable}} attribute value.
+    </dd>
+    <dt>{{target}}</dt>
+    <dd>
+        The <dfn export>target</dfn> attribute's getter returns the result of the <a link-for=''>get an element</a> algorithm, passing the <a link-for=''>context object</a>'s <a>target</a> and null as inputs.
     </dd>
 </dl>
 
@@ -370,6 +381,16 @@ Finalize event timing {#sec-fin-event-timing}
     1. Let <var>relevantGlobal</var> be <var>target</var>'s <a>relevant global object</a>.
     1. If <var>relevantGlobal</var> does not <a>implement</a> {{Window}}, return.
     1. Set <var>timingEntry</var>'s {{processingEnd}} to <var>processingEnd</var>.
+    1. Assert that <var>target</var> <a>implements</a> {{Node}}.
+
+    Note: this assertion holds due to the types of events supported by the Event Timing API.
+
+    1. Set <var>timingEntry</var>'s <a for=PerformanceEventTiming>target</a> to the result of calling the <a>get an element</a> algorithm with <var>target</var> and <var>relevantGlobal</var>'s <a>associated document</a> as inputs.
+
+    Note: This will set <a for=PerformanceEventTiming>target</a> to the last event target. So if <a>retargeting</a> occurs, the last target, closest to the <a for=tree>root</a>, will be used.
+
+    Issue: Change the linking of the "get an element" algorithm once it is moved to the DOM spec.
+
     1. Append <var>timingEntry</var> to <var>relevantGlobal</var>’s <a>pending event entries</a>.
 </div>
 


### PR DESCRIPTION
This PR adds support to get the last event target from the PerformanceEventTiming object.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/pull/77.html" title="Last updated on Apr 7, 2020, 4:06 PM UTC (1466ded)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/77/08fa3b5...1466ded.html" title="Last updated on Apr 7, 2020, 4:06 PM UTC (1466ded)">Diff</a>