### PR TITLE
Set EventCounts map

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -152,7 +152,7 @@ Certain types of events are considered, and timing information is exposed when t
     <!-- MouseEvents -->
         {{auxclick}}, {{click}}, {{dblclick}}, {{mousedown}}, {{mouseenter}}, {{mouseleave}}, {{mouseout}}, {{mouseover}}, {{mouseup}},
     <!-- PointerEvents -->
-        {{pointerover}}, {{pointerenter}}, {{pointerdown}}, {{pointerup}}, {{pointercancel}}, {{pointerout}}, {{pointerleave}}, {{gotpointercapture}}, {{lostpointercapture}}
+        {{pointerover}}, {{pointerenter}}, {{pointerdown}}, {{pointerup}}, {{pointercancel}}, {{pointerout}}, {{pointerleave}}, {{gotpointercapture}}, {{lostpointercapture}},
     <!-- TouchEvents -->
         {{touchstart}}, {{touchend}}, {{touchcancel}},
     <!-- KeyboardEvents -->
@@ -318,6 +318,8 @@ partial interface Performance {
 
 The {{Performance/eventCounts}} attribute's getter returns a map with entries of the form <var>type</var> → <var>numEvents</var>.
 This means that there have been <var>numEvents</var> dispatched such that their {{Event/type}} attribute value is equal to <var>type</var>.
+
+Upon construction of a {{Performance}} object whose [=relevant global object=] is a {{Window}}, the user agent must initialize the {{Performance/eventCounts}} attribute value to a map containing 0s for all event types that the user agent supports from the list described in [[#sec-events-exposed]].
 
 Processing model {#sec-processing-model}
 ========================================


### PR DESCRIPTION
This is perhaps a bit hand-wavy, but I notice hr-time doesn't even mention the construction of the Performance object so...

One question is whether the user agent should set all the possible events to 0, or only those which it can count. This is relevant for Chromium implementation as 'dragexit' is not implemented (in Chrome or elsewhere, but it is in HTML... that might change after https://github.com/whatwg/html/issues/2741 is resolved). In any case, it seems better to initialize to 0s only for event types you're currently counting.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/pull/79.html" title="Last updated on Apr 8, 2020, 10:53 PM UTC (a6fb2bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/79/47b5e3e...a6fb2bc.html" title="Last updated on Apr 8, 2020, 10:53 PM UTC (a6fb2bc)">Diff</a>