### PR TITLE
Remove context object usage

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -290,7 +290,7 @@ interface PerformanceEventTiming : PerformanceEntry {
 
 Each {{PerformanceEventTiming}} object has an associated <dfn for=PerformanceEventTiming>eventTarget</dfn>, which is initially set to null.
 
-The <dfn export>target</dfn> attribute's getter returns the result of the <a link-for=''>get an element</a> algorithm, passing the <a>this</a>'s <a>eventTarget</a> and null as inputs.
+The <dfn export>target</dfn> attribute's getter returns the result of the <a link-for=''>get an element</a> algorithm, passing <a>this</a>'s <a>eventTarget</a> and null as inputs.
 
 Note: A user agent implementing the Event Timing API would need to include "<code>first-input</code>" and "<code>event</code>" in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
 This allows developers to detect support for event timing.

--- a/index.bs
+++ b/index.bs
@@ -290,7 +290,7 @@ interface PerformanceEventTiming : PerformanceEntry {
 
 Each {{PerformanceEventTiming}} object has an associated <dfn for=PerformanceEventTiming>eventTarget</dfn>, which is initially set to null.
 
-The <dfn export>target</dfn> attribute's getter returns the result of the <a link-for=''>get an element</a> algorithm, passing the <a link-for=''>context object</a>'s <a>eventTarget</a> and null as inputs.
+The <dfn export>target</dfn> attribute's getter returns the result of the <a link-for=''>get an element</a> algorithm, passing the <a>this</a>'s <a>eventTarget</a> and null as inputs.
 
 Note: A user agent implementing the Event Timing API would need to include "<code>first-input</code>" and "<code>event</code>" in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts.
 This allows developers to detect support for event timing.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 6, 2021, 9:24 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2FWICG%2Fevent-timing%2F8505db2769e1c38bd78c4b038548e1c63a4bf9af%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
LINK ERROR: No 'dfn' refs found for 'context object'.
&lt;a data-link-for="" data-link-type="dfn" data-lt="context object">context object&lt;/a>
FATAL ERROR: Couldn't load MDN Spec Links data for this spec.
Expecting value: line 1 column 1 (char 0)
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/event-timing%23100.)._
</details>
