### PR TITLE
Be explicit about event type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -361,7 +361,7 @@ Each {{PerformanceEventTiming}} object reports timing information about an <dfn 
     </dd>
     <dt>{{interactionId}}</dt>
     <dd link-for=>
-      The <dfn export>interactionId</dfn> attribute's getter returns the ID that uniquely identifies the user interaction which triggered the <a>associated event</a>. This attribute is 0 unless the <a>associated event</a> is one of:
+      The <dfn export>interactionId</dfn> attribute's getter returns the ID that uniquely identifies the user interaction which triggered the <a>associated event</a>. This attribute is 0 unless the <a>associated event</a>'s {{Event/type}} attribute value is one of:
           * A {{pointerdown}}, {{pointerup}}, or {{click}} belonging to a user tap or drag. Note that {{pointerdown}} that ends in scroll is excluded.
           * A {{keydown}} or {{keyup}} belonging to a user key press.
     </dd>
@@ -490,7 +490,8 @@ Computing interactionId {#sec-computing-interactionid}
     When asked to <dfn export>compute interactionId</dfn> with |event| as input, run the following steps:
 
     1. If |event|'s {{Event/isTrusted}} attribute value is false, return 0.
-    1. If |event| is not one among {{keydown}}, {{keyup}}, {{pointercancel}}, {{pointerup}}, or {{click}}, return 0.
+    1. Let |type| be |event|'s {{Event/type}} attribute value.
+    1. If |type| is not one among {{keydown}}, {{keyup}}, {{pointercancel}}, {{pointerup}}, or {{click}}, return 0.
 
         Note: {{pointerdown}} is handled in <a>finalize event timing</a>, where an entry is added to <a>pending pointer downs</a>.
 
@@ -498,36 +499,36 @@ Computing interactionId {#sec-computing-interactionid}
     1. Let |keyMap| be |window|'s <a>key press interaction value map</a>.
     1. Let |pointerMap| be |window|'s <a>pointer interaction value map</a>.
     1. Let |pendingDowns| be |window|'s <a>pending pointer downs</a>.
-    1. If |event| is a {{keydown}} or {{keyup}}:
+    1. If |type| is {{keydown}} or {{keyup}}:
         1. Let |code| be |event|'s {{KeyboardEvent|code}} attribute value.
-        1. If |event| is a {{keydown}}:
+        1. If |type| is {{keydown}}:
             1. Increase |window|'s <a>user interaction value</a> value by a small number chosen by the user agent.
             1. Let |code| be |event|'s {{KeyboardEvent|code}} attribute value.
             1. Set |keyMap|[|code|] to |window|'s <a>user interaction value</a>.
             1. Return |keyMap|[|code|].
-        1. Otherwise (|event| is a {{keyup}}):
+        1. Otherwise (|type| is {{keyup}}):
             1. If |keyMap|[|code|] does not exist, return 0.
             1. Let |value| be |keyMap|[|code|].
             1. Remove |keyMap|[|code|].
             1. Return |value|.
-    1. Otherwise (event is {{pointercancel}}, {{pointerup}}, or {{click}}):
+    1. Otherwise (|type| is {{pointercancel}}, {{pointerup}}, or {{click}}):
         1. Let |pointerId| be |event|'s {{PointerEvent/pointerId}} attribute value.
-        1. If |event| is a {{click}}:
+        1. If |type| is {{click}}:
             1. If |pointerMap|[|pointerId|] does not exist, return 0.
             1. Let |value| be |pointerMap|[|pointerId|].
             1. Remove |pointerMap|[|pointerId|].
             1. Return |value|.
-        1. Assert that |event| is a {{pointerup}} or a {{pointercancel}}.
+        1. Assert that |type| is {{pointerup}} or {{pointercancel}}.
         1. If |pendingDowns|[|pointerId|] does not exist, return 0.
         1. Let |pointerDownEntry| be |pendingDowns|[|pointerId|].
         1. Assert that |pointerDownEntry| is a {{PerformanceEventTiming}} entry.
-        1. If |event| is a {{pointerup}}:
+        1. If |type| is {{pointerup}}:
             1. Increase |window|'s <a>user interaction value</a> value by a small number chosen by the user agent.
             1. Set |pointerMap|[|pointerId|] to |window|'s <a>user interaction value</a>.
             1. Set |pointerDownEntry|'s {{PerformanceEventTiming/interactionId}} to |pointerMap|[|pointerId|].
         1. Append |pointerDownEntry| to |window|’s <a>pending event entries</a>.
         1. Remove |pendingDowns|[|pointerId|].
-        1. If |event| is a {{pointercancel}}, return 0.
+        1. If |type| is {{pointercancel}}, return 0.
         1. Return |pointerMap|[|pointerId|].
 </div>
 
@@ -580,7 +581,7 @@ Finalize event timing {#sec-fin-event-timing}
 
         Issue: Change the linking of the "get an element" algorithm once it is moved to the DOM spec.
 
-    1. If |event| is not a {{pointerdown}}, append |timingEntry| to |relevantGlobal|’s <a>pending event entries</a>.
+    1. If |event|'s {{Event/type}} attribute value is not {{pointerdown}}, append |timingEntry| to |relevantGlobal|’s <a>pending event entries</a>.
     1. Otherwise:
         1. Let |pendingDowns| be |relevantGlobal|'s <a>pending pointer downs</a>.
         1. Let |pointerId| be |event|'s {{PointerEvent/pointerId}}.


### PR DESCRIPTION
Fixes https://github.com/WICG/event-timing/issues/104


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 503 Service Unavailable :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Oct 5, 2021, 8:52 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2FWICG%2Fevent-timing%2Fpull%2F106%2F9052a64.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2FWICG%2Fevent-timing%2Fpull%2F106.html)

```
<html><body><h1>503 Service Unavailable</h1>
No server is available to handle this request.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/event-timing%23106.)._
</details>
