### PR TITLE
Fix interactionID on IME

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -425,7 +425,7 @@ Modifications to the HTML specification {#sec-modifications-HTML}
 
 <em>This section will be removed once [[HTML]] has been modified.</em>
 
-Each {{Window}} has <dfn>pending event entries</dfn>, a list that stores {{PerformanceEventTiming}} objects, which will initially be empty.
+Each {{Window}} has <dfn>entries to be queued</dfn>, a list that stores {{PerformanceEventTiming}} objects, which will initially be empty.
 
 Each {{Window}} also has <dfn>pending first pointer down</dfn>, a pointer to a {{PerformanceEventTiming}} entry which is initially null.
 
@@ -493,7 +493,7 @@ Computing interactionId {#sec-computing-interactionid}
     1. Let |type| be |event|'s {{Event/type}} attribute value.
     1. If |type| is not one among {{keyup}}, {{compositionstart}}, {{input}}, {{pointercancel}}, {{pointerup}}, or {{click}}, return 0.
 
-        Note: {{pointerdown}} is handled in <a>finalize event timing</a>, where an entry is added to <a>pending pointer downs</a>.
+        Note: {{keydown}} and {{pointerdown}} are handled in <a>finalize event timing</a>.
 
     1. Let |window| be |event|'s <a>relevant global object</a>.
     1. Let |pendingKeyDowns| be |window|'s <a>pending key downs</a>.
@@ -507,12 +507,12 @@ Computing interactionId {#sec-computing-interactionid}
         1. Increase |window|'s <a>user interaction value</a> value by a small number chosen by the user agent.
         1. Let |interactionId| be |window|'s <a>user interaction value</a> value.
         1. Set |entry|'s {{PerformanceEventTiming/interactionId}} to |interactionId|.
-        1. Add |entry| to |window|'s <a>pending event entries</a>.
+        1. Add |entry| to |window|'s <a>entries to be queued</a>.
         1. <a for=map>Remove</a> |pendingKeyDowns|[|code|].
         1. Return |interactionId|.
     1. If |type| is {{compositionstart}}:
         1. For each |entry| in the <a for=map>values</a> of |pendingKeyDowns|:
-            1. Append |entry| to |window|'s <a>pending event entries</a>.
+            1. Append |entry| to |window|'s <a>entries to be queued</a>.
         1. <a for=map>Clear</a> |pendingKeyDowns|.
         1. Return 0.
     1. If |type| is {{input}}:
@@ -536,7 +536,7 @@ Computing interactionId {#sec-computing-interactionid}
             1. Increase |window|'s <a>user interaction value</a> value by a small number chosen by the user agent.
             1. Set |pointerMap|[|pointerId|] to |window|'s <a>user interaction value</a>.
             1. Set |pointerDownEntry|'s {{PerformanceEventTiming/interactionId}} to |pointerMap|[|pointerId|].
-        1. Append |pointerDownEntry| to |window|’s <a>pending event entries</a>.
+        1. Append |pointerDownEntry| to |window|’s <a>entries to be queued</a>.
         1. Remove |pendingPointerDowns|[|pointerId|].
         1. If |type| is {{pointercancel}}, return 0.
         1. Return |pointerMap|[|pointerId|].
@@ -591,15 +591,15 @@ Finalize event timing {#sec-fin-event-timing}
 
         Issue: Change the linking of the "get an element" algorithm once it is moved to the DOM spec.
 
-    1. If |event|'s {{Event/type}} attribute value is not {{keydown}} nor {{pointerdown}}, append |timingEntry| to |relevantGlobal|’s <a>pending event entries</a>.
+    1. If |event|'s {{Event/type}} attribute value is not {{keydown}} nor {{pointerdown}}, append |timingEntry| to |relevantGlobal|’s <a>entries to be queued</a>.
     1. If |event|'s {{Event/type}} attribute value is {{pointerdown}}:
         1. Let |pendingPointerDowns| be |relevantGlobal|'s <a>pending pointer downs</a>.
         1. Let |pointerId| be |event|'s {{PointerEvent/pointerId}}.
-        1. If |pendingPointerDowns|[|pointerId|] exists, append |pendingPointerDowns|[|pointerId|] to |relevantGlobal|'s <a>pending event entries</a>.
+        1. If |pendingPointerDowns|[|pointerId|] exists, append |pendingPointerDowns|[|pointerId|] to |relevantGlobal|'s <a>entries to be queued</a>.
         1. Set |pendingPointerDowns|[|pointerId|] to |timingEntry|.
     1. Otherwise (|event|'s {{Event/type}} attribute value is {{keydown}}):
         1. If |event|'s {{KeyboardEvent/isComposing}} attribute value is <code>true</code>:
-            1. Append |timingEntry| to |relevantGlobal|’s <a>pending event entries</a>.
+            1. Append |timingEntry| to |relevantGlobal|’s <a>entries to be queued</a>.
             1. Return.
         1. Let |pendingKeyDowns| be |relevantGlobal|'s <a>pending key downs</a>.
         1. Let |code| be |event|'s {{KeyboardEvent/keyCode}} attribute value.
@@ -609,7 +609,7 @@ Finalize event timing {#sec-fin-event-timing}
                 Note: 229 is a special case since it corresponds to IME keyboard events. Sometimes multiple of these are sent by the user agent, and they do not correspond holding a key down repeatedly.
                 1. Increase |window|'s <a>user interaction value</a> value by a small number chosen by the user agent.
                 1. Set |entry|'s {{PerformanceEventTiming/interactionId}} to |window|'s <a>user interaction value</a>.
-            1. Add |entry| to |window|'s <a>pending event entries</a>.
+            1. Add |entry| to |window|'s <a>entries to be queued</a>.
             1. <a for=map>Remove</a> |pendingKeyDowns|[|code|].
         1. Set |pendingKeyDowns|[|code|] to |timingEntry|.
 </div>
@@ -622,10 +622,10 @@ Dispatch pending Event Timing entries {#sec-dispatch-pending}
 
     1. Let <var>window</var> be <var>doc</var>'s <a>relevant global object</a>.
     1. Let <var>renderingTimestamp</var> be the <a>current high resolution time</a>.
-    1. For each <var>timingEntry</var> in <var>window</var>'s <a>pending event entries</a>:
+    1. For each <var>timingEntry</var> in <var>window</var>'s <a>entries to be queued</a>:
         1. <a>Set event timing entry duration</a> passing |timingEntry|, |window|, and |renderingTimestamp|.
         1. If |timingEntry|'s {{PerformanceEntry/duration}} attribute value is greater than or equal to 16, then <a lt='queue the entry'>queue</a> |timingEntry|.
-    1. Clear |window|'s <a>pending event entries</a>.
+    1. Clear |window|'s <a>entries to be queued</a>.
     1. For each |pendingDown| in the <a lt="get the values">values</a> from |window|'s <a>pending pointer downs</a>:
         1. <a>Set event timing entry duration</a> passing |pendingDown|, |window|, and |renderingTimestamp|.
 </div>


### PR DESCRIPTION
Extends keyboard tracking in order to correctly compute interactionID on IME cases. In order to do this, we track `input` events during composition instead of keyboard events. In addition, we do not necessarily consider lone `keydown` events as triggering a new interactionID. Instead, we need to wait for a `keyup` or for a subsequent `keydown` with the same `keyCode`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/pull/107.html" title="Last updated on Oct 28, 2021, 1:58 PM UTC (a9f83df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/event-timing/107/3ab776c...a9f83df.html" title="Last updated on Oct 28, 2021, 1:58 PM UTC (a9f83df)">Diff</a>