### PR TITLE
Fix 126: Add targetIdentifier to PerformanceEventTiming

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -742,7 +742,7 @@ Target Selectors {#sec-target-selectors}
             1. If |target| has an `id` attribute, set |selector| to the [=concatenate|concatenation=] of « |selector|, "#", the value of the `id` attribute ».
             1. Otherwise, if |target| has a `src` attribute, set |selector| to the [=concatenate|concatenation=] of « |selector|, "[src=", the value of the `src` attribute, "]" ».
         1. Return |selector|.
-    1. Otherwise, Return an empty string.
+    1. Otherwise, return an empty string.
 </div>
 
 Security & privacy considerations {#priv-sec}


### PR DESCRIPTION
The Event Timing API is part of the Performance Timeline and is used to measure the performance of user interactions. Each entry already report a `target` value, alongside the event timing information, which can be useful for attribution.

However, because observing performance entries is asynchronous, and potentially buffered, and because the `target` value is a weak reference -- by the time the Event Timing entry is observed, we might have already disconnected the node from the dom, and will now have a null `target` value.

One of the more common developer paint points, and thus feedback, about Event Timing is that it can be hard to debug/diagnose when the event timing target value is empty, and this offers no remedy to reproduce locally.

A workaround that is sometimes used is to save a `targetIdentifier` string value by registering event listeners, creating a map of all events and event target strings (custom serializing to query selector), and then later merging this with Event Timing entries once reported from the performance api (via `Event.type == EventTimingEntry.name` and `Event.timeStamp == EventTimingEntry.startTime`) -- but this largely negates the advantages of using the performance API in the first place.

For this reason, it is useful to capture a string identifier to represent the EventTarget at the time of event dispatch (and measurement). For now, this is a very simple string such as `tagName#id`.

---

This issue affects other performance apis which report on live nodes (e.g. element timings) but seems to be especially common for event timing, since the result of dispatching events will commonly modify the page in ways that remove the element that was used (e.g. clicking "close" or "accept" buttons will remove the UI).

Note: This also matches (and was borrowed from) the behaviour of the Long Animation Frame Timing API, for setting the `invoker` value of PerformanceScriptTiming when `invokerType` is an `event-listener`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmocny/event-timing/pull/160.html" title="Last updated on Oct 17, 2025, 11:42 AM UTC (ca488d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/event-timing/160/57dd243...mmocny:ca488d7.html" title="Last updated on Oct 17, 2025, 11:42 AM UTC (ca488d7)">Diff</a>