### PR TITLE
Fix #161: Fix broken links for Event types.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -427,7 +427,7 @@ interface EventCounts {
 };
 </pre>
 
-The {{EventCounts}} object is a map where the keys are event <a href=Event/type>types</a> and the values are the number of events that have been dispatched that are of that {{Event/type}}.
+The {{EventCounts}} object is a map where the keys are event {{Event/type|types}} and the values are the number of events that have been dispatched that are of that {{Event/type}}.
 Only events whose {{Event/type}} is supported by {{PerformanceEventTiming}} entries (see section [[#sec-events-exposed]]) are counted via this map.
 
 Extensions to the {{Performance}} interface {#sec-extensions}


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmocny/event-timing/pull/162.html" title="Last updated on Feb 23, 2026, 8:07 PM UTC (ca27b29)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/event-timing/162/58243c2...mmocny:ca27b29.html" title="Last updated on Feb 23, 2026, 8:07 PM UTC (ca27b29)">Diff</a>