### PR TITLE
Update from api.csswg.org/bikeshed to spec-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ local: index.bs
 	bikeshed --die-on=warning spec index.bs index.html
 
 index.html: index.bs
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	@ (HTTP_STATUS=$$(curl https://www.w3.org/publications/spec-generator/ \
 	                       --output index.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
+	                       -F type=bikeshed-spec \
 	                       -F die-on=warning \
 	                       -F file=@index.bs) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \


### PR DESCRIPTION
This updates the Makefile to reference spec-generator instead of the discontinued CSSWG Bikeshed service.

I've verified that `make index.html` runs successfully with output similar to the current ED.